### PR TITLE
自分の出品した物を入札できない処理と自分のオークションを終了させる処理を追加

### DIFF
--- a/src/main/java/oit/is/uno/auction/controller/AuctionController.java
+++ b/src/main/java/oit/is/uno/auction/controller/AuctionController.java
@@ -73,9 +73,23 @@ public class AuctionController {
   public String bid(@RequestParam Integer auctionId, ModelMap model, Principal prin) {
 
     AuctionInfo auctionInfo = aMapper.selectById(auctionId);
-
+    String userName = prin.getName();
+    if (auctionInfo.getSellerName().equals(userName)) {
+      model.addAttribute("seller", userName);
+    } else {
+      model.addAttribute("bidder", userName);
+    }
     model.addAttribute("auctionInfo", auctionInfo);
     return "bid.html";
+  }
+
+  @GetMapping("/bid/end")
+  public String end(@RequestParam Integer auctionId) {
+    AuctionInfo newInfo = aMapper.selectById(auctionId);
+    int itemId = iMapper.selectItemIdByName(newInfo.getItemName());
+    awMapper.insertAward(newInfo.getBidderId(), itemId);
+    aService.syncItemSold(auctionId);
+    return "auction.html";
   }
 
   @PostMapping("/bid/insert")
@@ -102,6 +116,7 @@ public class AuctionController {
 
     newInfo = aMapper.selectById(auctionId);
     model.addAttribute("auctionInfo", newInfo);
+    model.addAttribute("bidder", prin.getName());
     return "bid.html";
   }
 

--- a/src/main/resources/templates/bid.html
+++ b/src/main/resources/templates/bid.html
@@ -14,12 +14,17 @@
   <p>最高入札額:[[${auctionInfo.maxBid}]]</p>
 
   <div sec:authorize="hasRole('ROLE_USER')">
-    <form action="/auction/bid/insert" method="post">
-      <input type="number" name="bid" value="0" min="0" />
-      <input type="hidden" name="role" th:value="user" />
-      <input type="hidden" name="auctionId" th:value="${auctionInfo.id}">
-      <input type="submit" value="入札">
-    </form>
+    <span th:if="${seller}">
+      <a th:href="@{/auction/bid/end(auctionId=${auctionInfo.id})}">オークションを終了する</a>
+    </span>
+    <span th:if="${bidder}">
+      <form action="/auction/bid/insert" method="post">
+        <input type="number" name="bid" value="0" min="0" />
+        <input type="hidden" name="role" th:value="user" />
+        <input type="hidden" name="auctionId" th:value="${auctionInfo.id}">
+        <input type="submit" value="入札">
+      </form>
+    </span>
   </div>
 
   <div sec:authorize="hasRole('ROLE_ADMIN')">


### PR DESCRIPTION
[DoD]
オークションページにアクセスして、出品者の欄で自分のユーザー名であれば、入札用ページには、オークションの詳細とオークションを終了するためのリンクだけが表示される
なお、リンクを押すと、オークションページにもどり、その行のオークションは終了されている（表から消える）
